### PR TITLE
fixes ES6 in mjs files.

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "outDir": "dist",
-    "target": "es6",
+    "target": "es5",
     "module": "es6",
     "moduleResolution": "node",
     "declaration": true,


### PR DESCRIPTION
Fixes #8 
By setting `target` to `es5`, the `.mjs` bundle only contains ES5 code. Without that, the `vue-runtime-helpers` dependency has to be transpiled in all consuming projects, i.e. by using `@rollup/plugin-babel` and including `vue-runtime-helpers` in the transpilation process. If you don't do that, resulting bundles contain ES6 bug, which doesn't work in IE environments.

Shipping ES6 bundles is also discourged (see #8).

I've also found a related PR that would have had the same effect, but might be outdated today. [This comment](https://github.com/znck/vue-runtime-helpers/pull/1#issuecomment-457792610) suggests using `main` instead of `module` using `@rollup/plugin-node-resolve`, but as far as I know there is no way of doing this on a per-dependency basis. Other libraries might still be referenced by module, not main. Related PR: #1 


